### PR TITLE
OSX fixes

### DIFF
--- a/sdl/main.c
+++ b/sdl/main.c
@@ -230,7 +230,9 @@ static void handle_keydown(
 int main(int argc, char **argv) {
   (void)argc;
   (void)argv;
+#ifdef ENABLE_SSE
   if (__builtin_cpu_supports("sse2")) opna_ssg_sinc_calc_func = opna_ssg_sinc_calc_sse2;
+#endif
   fft_init_table();
   if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO)) {
     SDL_Log("Cannot initialize SDL\n");

--- a/sdl/main.c
+++ b/sdl/main.c
@@ -1,4 +1,8 @@
+#ifdef SDL_FRAMEWORK
+#include <SDL2/SDL.h>
+#else
 #include <SDL.h>
+#endif
 #include <stdbool.h>
 #include <stdatomic.h>
 #include "pacc/pacc.h"

--- a/sdl/osx/Makefile
+++ b/sdl/osx/Makefile
@@ -19,6 +19,7 @@ TARGET:=98fmplayersdl
 CFLAGS:=-Wall -Wextra -O2 -g
 CFLAGS:=-DLIBOPNA_ENABLE_LEVELDATA
 CFLAGS+=-DPACC_GL_3
+CFLAGS+=--target=x86_64-apple-darwin
 #CFLAGS+=-DPACC_GL_ES
 #CFLAGS+=-DPACC_GL_ES -DPACC_GL_3
 CFLAGS+=-I. -I.. -I../..
@@ -26,6 +27,8 @@ SDLFW:=/Library/Frameworks/SDL2.framework
 CFLAGS+=-I$(SDLFW)/Headers
 LIBS:=-framework SDL2 -framework OpenGL -liconv
 LIBS+=-F/Library/Frameworks
+LIBS+=--target=x86_64-apple-darwin
+LIBS+=-Wl,-rpath,@executable_path/../Frameworks
 
 $(TARGET):	$(OBJS)
 	$(CC) -o $@ $^ $(LIBS)

--- a/sdl/osx/Makefile
+++ b/sdl/osx/Makefile
@@ -7,19 +7,22 @@ vpath %.c ../../fmdriver
 vpath %.c ../../fft
 #XCRUN:=xcrun --sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk/
 XCRUN:=xcrun
+UNAME_M:=$(UNAME -m)
 CC:=$(XCRUN) cc
 OBJS:=main.o
 OBJS+=pacc-gl.o
 OBJS+=fmdsp-pacc.o font_fmdsp_small.o fmdsp_platform_mach.o font_rom.o
-OBJS+=opna.o opnafm.o opnassg.o opnadrum.o opnaadpcm.o opnatimer.o opnassg-sinc-c.o opnassg-sinc-sse2.o
+OBJS+=opna.o opnafm.o opnassg.o opnadrum.o opnaadpcm.o opnatimer.o opnassg-sinc-c.o
 OBJS+=fmdriver_pmd.o fmdriver_fmp.o ppz8.o fmdriver_common.o
 OBJS+=fmplayer_file.o fmplayer_work_opna.o fmplayer_file_unix.o fmplayer_drumrom_unix.o fmplayer_fontrom_unix.o
 OBJS+=fft.o
+ifeq ($(UNAME_M),x86_64)
+OBJS+=opnassg-sinc-sse2.o
+endif
 TARGET:=98fmplayersdl
 CFLAGS:=-Wall -Wextra -O2 -g
 CFLAGS:=-DLIBOPNA_ENABLE_LEVELDATA
 CFLAGS+=-DPACC_GL_3
-CFLAGS+=--target=x86_64-apple-darwin
 #CFLAGS+=-DPACC_GL_ES
 #CFLAGS+=-DPACC_GL_ES -DPACC_GL_3
 CFLAGS+=-I. -I.. -I../..
@@ -28,7 +31,6 @@ CFLAGS+=-DSDL_FRAMEWORK
 CFLAGS+=-F/Library/Frameworks
 LIBS:=-framework SDL2 -framework OpenGL -liconv
 LIBS+=-F/Library/Frameworks
-LIBS+=--target=x86_64-apple-darwin
 LIBS+=-Wl,-rpath,@executable_path/../Frameworks
 
 $(TARGET):	$(OBJS)

--- a/sdl/osx/Makefile
+++ b/sdl/osx/Makefile
@@ -24,7 +24,8 @@ CFLAGS+=--target=x86_64-apple-darwin
 #CFLAGS+=-DPACC_GL_ES -DPACC_GL_3
 CFLAGS+=-I. -I.. -I../..
 SDLFW:=/Library/Frameworks/SDL2.framework
-CFLAGS+=-I$(SDLFW)/Headers
+CFLAGS+=-DSDL_FRAMEWORK
+CFLAGS+=-F/Library/Frameworks
 LIBS:=-framework SDL2 -framework OpenGL -liconv
 LIBS+=-F/Library/Frameworks
 LIBS+=--target=x86_64-apple-darwin


### PR DESCRIPTION
This contains a few fixes for building the SDL OSX app:

* Disables building the SSE code on non-x86_64 platforms like ARM64.
* Adds an rpath for SDL2 to ensure the built app bundle can find it. Without this, the executable won't look inside the app bundle for `SDL2.framework`.
* Adds a missing `ENABLE_SSE` guard in `sdl/main.c`. A few other uses of SSE-specific code are guarded with this.
* Fixes including headers from the SDL2 framework in more recent releases of SDL2.